### PR TITLE
Fix auto-require interceptor

### DIFF
--- a/src/plasma/server/interceptors.clj
+++ b/src/plasma/server/interceptors.clj
@@ -20,7 +20,7 @@
               (require ns)
               (when on-required
                 (on-required ns)
-                (assoc-in ctx [:request fn-var] (resolve event-name))))
+                (assoc-in ctx [:request :fn-var] (resolve event-name))))
             (catch java.io.FileNotFoundException _
               ctx)))))}))
 


### PR DESCRIPTION
fix: use keyword, not var name in assoc-in

This was a doozy... auto-require is finally working for me (on the first
request).