### PR TITLE
deps: update outdated dependencies

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,8 +1,12 @@
 {:paths ["src"]
  :deps
- {funcool/promesa            {:mvn/version "5.1.0"}
-  manifold/manifold          {:mvn/version "0.1.9-alpha3"}
-  com.cognitect/transit-clj  {:mvn/version "1.0.324"}
-  com.cognitect/transit-cljs {:mvn/version "0.8.269"}
+ {funcool/promesa            {:mvn/version "8.0.450"}
+  manifold/manifold          {:mvn/version "0.2.4"}
+  com.cognitect/transit-clj  {:mvn/version "1.0.329"}
+  com.cognitect/transit-cljs {:mvn/version "0.8.280"}
   org.clojure/core.match     {:mvn/version "1.0.0"}
-  metosin/sieppari           {:mvn/version "0.0.0-alpha13"}}}
+  metosin/sieppari           {:mvn/version "0.0.0-alpha13"}}
+
+ :aliases
+ {:outdated {:extra-deps {com.github.liquidz/antq {:mvn/version "1.9.867"}}
+             :main-opts  ["-m" "antq.core"]}}}


### PR DESCRIPTION
Also adds an alias for listing the outdated deps,
runnable via `clj -M:outdated`.