### PR TITLE
client reconnect and stream re-request

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,12 +1,12 @@
 {:paths ["src"]
  :deps
- {funcool/promesa            {:mvn/version "8.0.450"}
-  manifold/manifold          {:mvn/version "0.2.4"}
-  com.cognitect/transit-clj  {:mvn/version "1.0.329"}
+ {funcool/promesa            {:mvn/version "11.0.678"}
+  manifold/manifold          {:mvn/version "0.4.3"}
+  com.cognitect/transit-clj  {:mvn/version "1.0.333"}
   com.cognitect/transit-cljs {:mvn/version "0.8.280"}
-  org.clojure/core.match     {:mvn/version "1.0.0"}
+  org.clojure/core.match     {:mvn/version "1.1.0"}
   metosin/sieppari           {:mvn/version "0.0.0-alpha13"}}
 
  :aliases
- {:outdated {:extra-deps {com.github.liquidz/antq {:mvn/version "1.9.867"}}
+ {:outdated {:extra-deps {com.github.liquidz/antq {:mvn/version "2.11.1250"}}
              :main-opts  ["-m" "antq.core"]}}}


### PR DESCRIPTION
Refactors `plasma.client/websocket-transport` to recreate the websocket on
disconnect, with an exponential back-off.

An important piece of this is re-`:plasma/request`-ing the known streams on
reconnect, so the frontend defstreams continue to consume from the backend once the
client has reconnected.

This supports clients staying connected to streams across server restarts, which
is helpful especially when developing against your own server, or otherwise
restarting it by hand (the current behavior requires a browser refresh to
restore defhandler/defstream usage).

Two new attrs are supported on `plasma.client/websocket-transport`:
- `:auto-reconnect?` - defaults to true, disable with `nil` or `false`
- `:on-reconnect` - a function invoked after a successful reconnect.

~~Note that `on-reconnect` is called before `on-open` for now,
and `on-open` is still called when reconnecting - perhaps we
should only invoke one of these.~~ `on-open` is called when first
connecting (never when reconnecting), `on-reconnect` is called when 
reconnecting.

Feel free to call out any style/re-arrangement/refactors - it feels like there
could be a cleaner impl than doing this all in `websocket-transport`, but
there's also a bunch of context to share across the send/open/close/message
funcs, so maybe it's best as is.